### PR TITLE
Adds defaults for some keys and adds option to upload files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ windows_iis_websites: []
   #   physical_path: c:\inetpub\wwwroot
   #   port: 80
   #   state: started
+  #   upload_files: path/to/dir/
+
+`upload_files` can be either a single file or a directory. If it is a directory
+ending with a `/`, then the directory contents will be uploaded. If it is
+a directory not ending with `/`, the directory itself will be uploaded under
+`physical_path`.
+
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,4 @@ windows_iis_websites: []
   #   physical_path: c:\inetpub\wwwroot
   #   port: 80
   #   state: started
+  #   upload_files: path/to/dir/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
 
   license: license (MIT)
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.5
 
   platforms:
     - name: Windows

--- a/tasks/features.yml
+++ b/tasks/features.yml
@@ -4,16 +4,14 @@
     include_management_tools: "{{ item['include_management_tools']|default(omit) }}"
     include_sub_features: "{{ item['include_sub_features']|default(omit) }}"
     name: "{{ item['name'] }}"
-    state: "{{ item['state'] }}"
+    state: "{{ item['state'] | default('present') }}"
   register: _windows_iis_services
   with_items: "{{ windows_iis_role }}"
 
 - name: features | Managing IIS Subfeatures
   win_feature:
     name: "{{ item[1]['name'] }}"
-    state: "{{ item[1]['state'] }}"
+    state: "{{ item[1]['state'] | default('present') }}"
   register: _windows_iis_subfeatures
-  with_subelements:
-    - "{{ windows_iis_role }}"
-    - subfeatures
+  loop: "{{ windows_iis_role | subelements('subfeatures', skip_missing=True) }}"
   when: item[0]['state']|lower == 'present'

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -4,6 +4,6 @@
 
 - name: reboot | Rebooting Server
   win_reboot:
-    reboot_timeout_sec: 3600
-    shutdown_timeout_sec: 3600
+    reboot_timeout: 3600
+    shutdown_timeout: 3600
   when: ansible_reboot_pending

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -5,7 +5,7 @@
   with_items: "{{ windows_iis_role }}"
   when: >
         item['name'] == "Web-Server" and
-        item['state']|lower == "present"
+        item['state'] | default('present') | lower == "present"
 
 - name: set_facts | Setting Web Server Fact
   set_fact:
@@ -13,4 +13,4 @@
   with_items: "{{ windows_iis_role }}"
   when: >
         item['name'] == "Web-Server" and
-        item['state']|lower == "absent"
+        item['state'] | default('present') | lower == "absent"

--- a/tasks/websites.yml
+++ b/tasks/websites.yml
@@ -16,3 +16,12 @@
     ssl: "{{ item['ssl']|default(omit) }}"
     state: "{{ item['state'] }}"
   with_items: "{{ windows_iis_websites }}"
+
+- name: Upload website files
+  win_copy:
+    src: "{{ item['upload_files'] }}"
+    dest: "{{ item['physical_path'] }}\\"
+  when:
+    - item['upload_files'] is defined
+    - item['upload_files'] | length > 0
+  with_items: "{{ windows_iis_websites }}"


### PR DESCRIPTION
The first commit adds defaults for keys like `present` which in ansible are generally omitted if equal to `present`. I have also made a couple more changes to remove warning for  ansible >2.5 . Ansible 2.5 is more or less the minimum officially supported version (as 2.8 is about to come out and the deprecation cycle in ansible is 4 minor releases long).

The second commit add an option for some simple file upload mechanism so that the user can also upload files to websites. 

I hope you find these two useful.