### PR TITLE
Adds collections info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,3 +16,6 @@ galaxy_info:
     - webserver
 
 dependencies: []
+collections:
+  - ansible.windows
+  - community.windows


### PR DESCRIPTION
Ansible 2.10 restructures the project and moves plugins and modules to collections. Each role will **need** to specify in its meta file which collections it uses. This change is also supported by ansible 2.9 but it is also backwards compatible with older versions.